### PR TITLE
More robust root path location

### DIFF
--- a/Yabber/Formats/YBND3.cs
+++ b/Yabber/Formats/YBND3.cs
@@ -44,6 +44,7 @@ namespace Yabber
             string strBigEndian = xml.SelectSingleNode("bnd3/bigendian")?.InnerText ?? "False";
             string strBitBigEndian = xml.SelectSingleNode("bnd3/bitbigendian")?.InnerText ?? "False";
             string strUnk18 = xml.SelectSingleNode("bnd3/unk18")?.InnerText ?? "0x0";
+            string strRoot = xml.SelectSingleNode("bnd3/root")?.InnerText ?? "";
 
             if (!Enum.TryParse(strCompression, out DCX.Type compression))
                 throw new FriendlyException($"Could not parse compression type: {strCompression}");
@@ -76,7 +77,7 @@ namespace Yabber
             }
 
             if (xml.SelectSingleNode("bnd3/files") != null)
-                YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd3/files"), sourceDir);
+                YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd3/files"), sourceDir, strRoot);
 
             string outPath = $"{targetDir}\\{filename}";
             YBUtil.Backup(outPath);

--- a/Yabber/Formats/YBND3.cs
+++ b/Yabber/Formats/YBND3.cs
@@ -38,13 +38,14 @@ namespace Yabber
                 throw new FriendlyException("Missing filename tag.");
 
             string filename = xml.SelectSingleNode("bnd3/filename").InnerText;
+            string root = xml.SelectSingleNode("bnd3/root")?.InnerText ?? "";
+
             string strCompression = xml.SelectSingleNode("bnd3/compression")?.InnerText ?? "None";
             bnd.Version = xml.SelectSingleNode("bnd3/version")?.InnerText ?? "07D7R6";
             string strFormat = xml.SelectSingleNode("bnd3/format")?.InnerText ?? "IDs, Names1, Names2, Compression";
             string strBigEndian = xml.SelectSingleNode("bnd3/bigendian")?.InnerText ?? "False";
             string strBitBigEndian = xml.SelectSingleNode("bnd3/bitbigendian")?.InnerText ?? "False";
             string strUnk18 = xml.SelectSingleNode("bnd3/unk18")?.InnerText ?? "0x0";
-            string strRoot = xml.SelectSingleNode("bnd3/root")?.InnerText ?? "";
 
             if (!Enum.TryParse(strCompression, out DCX.Type compression))
                 throw new FriendlyException($"Could not parse compression type: {strCompression}");
@@ -77,7 +78,7 @@ namespace Yabber
             }
 
             if (xml.SelectSingleNode("bnd3/files") != null)
-                YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd3/files"), sourceDir, strRoot);
+                YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd3/files"), sourceDir, root);
 
             string outPath = $"{targetDir}\\{filename}";
             YBUtil.Backup(outPath);

--- a/Yabber/Formats/YBND4.cs
+++ b/Yabber/Formats/YBND4.cs
@@ -37,7 +37,7 @@ namespace Yabber
             xml.Load($"{sourceDir}\\_yabber-bnd4.xml");
 
             string filename = xml.SelectSingleNode("bnd4/filename").InnerText;
-            var root = xml.SelectSingleNode("bnd4/root").InnerText ?? "";
+            var root = xml.SelectSingleNode("bnd4/root")?.InnerText ?? "";
 
             Enum.TryParse(xml.SelectSingleNode("bnd4/compression")?.InnerText ?? "None", out DCX.Type compression);
             bnd.Compression = compression;

--- a/Yabber/Formats/YBND4.cs
+++ b/Yabber/Formats/YBND4.cs
@@ -48,7 +48,10 @@ namespace Yabber
             bnd.Extended = Convert.ToByte(xml.SelectSingleNode("bnd4/extended").InnerText, 16);
             bnd.Unk04 = bool.Parse(xml.SelectSingleNode("bnd4/unk04").InnerText);
             bnd.Unk05 = bool.Parse(xml.SelectSingleNode("bnd4/unk05").InnerText);
-            YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd4/files"), sourceDir);
+
+            var root = xml.SelectSingleNode("bnd4/root").InnerText ?? "";
+
+            YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd4/files"), sourceDir, root);
 
             string outPath = $"{targetDir}\\{filename}";
             YBUtil.Backup(outPath);

--- a/Yabber/Formats/YBND4.cs
+++ b/Yabber/Formats/YBND4.cs
@@ -37,6 +37,8 @@ namespace Yabber
             xml.Load($"{sourceDir}\\_yabber-bnd4.xml");
 
             string filename = xml.SelectSingleNode("bnd4/filename").InnerText;
+            var root = xml.SelectSingleNode("bnd4/root").InnerText ?? "";
+
             Enum.TryParse(xml.SelectSingleNode("bnd4/compression")?.InnerText ?? "None", out DCX.Type compression);
             bnd.Compression = compression;
 
@@ -48,8 +50,6 @@ namespace Yabber
             bnd.Extended = Convert.ToByte(xml.SelectSingleNode("bnd4/extended").InnerText, 16);
             bnd.Unk04 = bool.Parse(xml.SelectSingleNode("bnd4/unk04").InnerText);
             bnd.Unk05 = bool.Parse(xml.SelectSingleNode("bnd4/unk05").InnerText);
-
-            var root = xml.SelectSingleNode("bnd4/root").InnerText ?? "";
 
             YBinder.ReadBinderFiles(bnd, xml.SelectSingleNode("bnd4/files"), sourceDir, root);
 

--- a/Yabber/Formats/YBXF3.cs
+++ b/Yabber/Formats/YBXF3.cs
@@ -35,12 +35,14 @@ namespace Yabber
 
             string bhdFilename = xml.SelectSingleNode("bxf3/bhd_filename").InnerText;
             string bdtFilename = xml.SelectSingleNode("bxf3/bdt_filename").InnerText;
+            string root = xml.SelectSingleNode("bxf3/root").InnerText ?? "";
+
             bxf.Version = xml.SelectSingleNode("bxf3/version").InnerText;
             bxf.Format = (Binder.Format)Enum.Parse(typeof(Binder.Format), xml.SelectSingleNode("bxf3/format").InnerText);
             bxf.BigEndian = bool.Parse(xml.SelectSingleNode("bxf3/bigendian").InnerText);
             bxf.BitBigEndian = bool.Parse(xml.SelectSingleNode("bxf3/bitbigendian").InnerText);
 
-            YBinder.ReadBinderFiles(bxf, xml.SelectSingleNode("bxf3/files"), sourceDir);
+            YBinder.ReadBinderFiles(bxf, xml.SelectSingleNode("bxf3/files"), sourceDir, root);
 
             string bhdPath = $"{targetDir}\\{bhdFilename}";
             YBUtil.Backup(bhdPath);

--- a/Yabber/Formats/YBXF3.cs
+++ b/Yabber/Formats/YBXF3.cs
@@ -35,7 +35,7 @@ namespace Yabber
 
             string bhdFilename = xml.SelectSingleNode("bxf3/bhd_filename").InnerText;
             string bdtFilename = xml.SelectSingleNode("bxf3/bdt_filename").InnerText;
-            string root = xml.SelectSingleNode("bxf3/root").InnerText ?? "";
+            string root = xml.SelectSingleNode("bxf3/root")?.InnerText ?? "";
 
             bxf.Version = xml.SelectSingleNode("bxf3/version").InnerText;
             bxf.Format = (Binder.Format)Enum.Parse(typeof(Binder.Format), xml.SelectSingleNode("bxf3/format").InnerText);

--- a/Yabber/Formats/YBXF4.cs
+++ b/Yabber/Formats/YBXF4.cs
@@ -39,7 +39,7 @@ namespace Yabber
 
             string bhdFilename = xml.SelectSingleNode("bxf4/bhd_filename").InnerText;
             string bdtFilename = xml.SelectSingleNode("bxf4/bdt_filename").InnerText;
-            string root = xml.SelectSingleNode("bx4/root").InnerText;
+            string root = xml.SelectSingleNode("bxf4/root")?.InnerText ?? "";
 
             bxf.Version = xml.SelectSingleNode("bxf4/version").InnerText;
             bxf.Format = (Binder.Format)Enum.Parse(typeof(Binder.Format), xml.SelectSingleNode("bxf4/format").InnerText);

--- a/Yabber/Formats/YBXF4.cs
+++ b/Yabber/Formats/YBXF4.cs
@@ -39,6 +39,8 @@ namespace Yabber
 
             string bhdFilename = xml.SelectSingleNode("bxf4/bhd_filename").InnerText;
             string bdtFilename = xml.SelectSingleNode("bxf4/bdt_filename").InnerText;
+            string root = xml.SelectSingleNode("bx4/root").InnerText;
+
             bxf.Version = xml.SelectSingleNode("bxf4/version").InnerText;
             bxf.Format = (Binder.Format)Enum.Parse(typeof(Binder.Format), xml.SelectSingleNode("bxf4/format").InnerText);
             bxf.BigEndian = bool.Parse(xml.SelectSingleNode("bxf4/bigendian").InnerText);
@@ -48,7 +50,7 @@ namespace Yabber
             bxf.Unk04 = bool.Parse(xml.SelectSingleNode("bxf4/unk04").InnerText);
             bxf.Unk05 = bool.Parse(xml.SelectSingleNode("bxf4/unk05").InnerText);
 
-            YBinder.ReadBinderFiles(bxf, xml.SelectSingleNode("bxf4/files"), sourceDir);
+            YBinder.ReadBinderFiles(bxf, xml.SelectSingleNode("bxf4/files"), sourceDir, root);
 
             string bhdPath = $"{targetDir}\\{bhdFilename}";
             YBUtil.Backup(bhdPath);

--- a/Yabber/Formats/YBinder.cs
+++ b/Yabber/Formats/YBinder.cs
@@ -17,9 +17,9 @@ namespace Yabber
             {
                 root = YBUtil.FindCommonRootPath(bnd.Files.Select(bndFile => bndFile.Name));
 
-                // Find the shared root path
                 if (root != "")
                 {
+                    // If there is a common root path, add it to the XML so it can be used in repacking.
                     xw.WriteElementString("root", root+"\\");
                 }
 

--- a/Yabber/Formats/YBinder.cs
+++ b/Yabber/Formats/YBinder.cs
@@ -11,24 +11,18 @@ namespace Yabber
     {
         public static void WriteBinderFiles(BinderReader bnd, XmlWriter xw, string targetDir, IProgress<float> progress)
         {
+
             string root = "";
             if (Binder.HasNames(bnd.Format))
             {
+                root = YBUtil.FindCommonRootPath(bnd.Files.Select(bndFile => bndFile.Name));
+
                 // Find the shared root path
-                var paths = bnd.Files.Select(bndFile => bndFile.Name);
-
-                var rootPath = new string(
-                    paths.First().Substring(0, paths.Min(s => s.Length))
-                        .TakeWhile((c, i) => paths.All(s => s[i] == c)).ToArray());
-
-                var rootPathIndex = Math.Max(rootPath.LastIndexOf('\\'), rootPath.LastIndexOf('/'));
-
-                if (rootPath != "" && rootPathIndex != -1)
+                if (root != "")
                 {
-                    // We do be havin a shared root path
-                    root = rootPath.Substring(0, rootPathIndex);
                     xw.WriteElementString("root", root+"\\");
                 }
+
             }
 
             xw.WriteStartElement("files");

--- a/Yabber/YBUtil.cs
+++ b/Yabber/YBUtil.cs
@@ -14,6 +14,10 @@ namespace Yabber
         private static readonly Regex TraversalRx = new Regex(@"^([(..)\\\/]+)(.+)?$");
         private static readonly Regex SlashRx = new Regex(@"^(\\+)(.+)$");
 
+
+        /// <summary>
+        /// Finds common path prefix in a list of strings.
+        /// </summary>
         public static string FindCommonRootPath(IEnumerable<string> paths)
         {
             string root = "";
@@ -22,11 +26,11 @@ namespace Yabber
                 paths.First().Substring(0, paths.Min(s => s.Length))
                     .TakeWhile((c, i) => paths.All(s => s[i] == c)).ToArray());
 
+            // For safety, truncate this shared string down to the last slash/backslash.
             var rootPathIndex = Math.Max(rootPath.LastIndexOf('\\'), rootPath.LastIndexOf('/'));
 
             if (rootPath != "" && rootPathIndex != -1)
             {
-                // A shared root path exists; write it into the XML and use it for paths.
                 root = rootPath.Substring(0, rootPathIndex);
             }
 

--- a/Yabber/YBUtil.cs
+++ b/Yabber/YBUtil.cs
@@ -10,48 +10,6 @@ namespace Yabber
 {
     static class YBUtil
     {
-        private static List<string> pathRoots = new List<string>
-        {
-            // Demon's Souls
-            @"N:\DemonsSoul\data\DVDROOT\",
-            @"N:\DemonsSoul\data\",
-            @"N:\DemonsSoul\",
-            @"Z:\data\",
-            // Ninja Blade
-            @"I:\NinjaBlade\",
-            // Dark Souls 1
-            @"N:\FRPG\data\INTERROOT_win32\",
-            @"N:\FRPG\data\INTERROOT_win64\",
-            @"N:\FRPG\data\INTERROOT_x64\",
-            @"N:\FRPG\data\INTERROOT\",
-            @"N:\FRPG\data\",
-            @"N:\FRPG\",
-            // Dark Souls 2
-            @"N:\FRPG2\data",
-            @"N:\FRPG2\",
-            @"N:\FRPG2_64\data\",
-            @"N:\FRPG2_64\",
-            // Dark Souls 3
-            @"N:\FDP\data\INTERROOT_ps4\",
-            @"N:\FDP\data\INTERROOT_win64\",
-            @"N:\FDP\data\INTERROOT_xboxone\",
-            @"N:\FDP\data\",
-            @"N:\FDP\",
-            // Bloodborne
-            @"N:\SPRJ\data\DVDROOT_win64\",
-            @"N:\SPRJ\data\INTERROOT_ps4\",
-            @"N:\SPRJ\data\INTERROOT_ps4_havok\",
-            @"N:\SPRJ\data\INTERROOT_win64\",
-            @"N:\SPRJ\data\",
-            @"N:\SPRJ\",
-            // Sekiro
-            @"N:\NTC\data\Target\INTERROOT_win64_havok\",
-            @"N:\NTC\data\Target\INTERROOT_win64\",
-            @"N:\NTC\data\Target\",
-            @"N:\NTC\data\",
-            @"N:\NTC\",
-        };
-
         private static readonly Regex DriveRx = new Regex(@"^(\w\:\\)(.+)$");
         private static readonly Regex TraversalRx = new Regex(@"^([(..)\\\/]+)(.+)?$");
         private static readonly Regex SlashRx = new Regex(@"^(\\+)(.+)$");
@@ -59,43 +17,31 @@ namespace Yabber
         /// <summary>
         /// Removes common network path roots if present.
         /// </summary>
-        public static string UnrootBNDPath(string path, out string root)
+        public static string UnrootBNDPath(string path, string root)
         {
-            root = "";
-            foreach (string pathRoot in pathRoots)
-            {
-                if (path.ToLower().StartsWith(pathRoot.ToLower()))
-                {
-                    root = path.Substring(0, pathRoot.Length);
-                    path = path.Substring(pathRoot.Length);
-                    break;
-                }
-            }
+            path = path.Substring(root.Length);
 
             Match drive = DriveRx.Match(path);
             if (drive.Success)
             {
-                root = drive.Groups[1].Value;
                 path = drive.Groups[2].Value;
             }
             
             Match traversal = TraversalRx.Match(path);
             if (traversal.Success)
             {
-                root += traversal.Groups[1].Value;
                 path = traversal.Groups[2].Value;
             }
             if (path.Contains("..\\") || path.Contains("../")) throw new InvalidDataException($"the path {path} contains invalid data, attempting to extract to a different folder. Please report this bnd to Nordgaren.");
-            return RemoveLeadingBackslashes(path, ref root);
+            return RemoveLeadingBackslashes(path);
         }
 
-        private static string RemoveLeadingBackslashes(string path, ref string root)
+        private static string RemoveLeadingBackslashes(string path)
         {
 
             Match slash = SlashRx.Match(path);
             if (slash.Success)
             {
-                root += slash.Groups[1].Value;
                 path = slash.Groups[2].Value;
             }
             return path;

--- a/Yabber/YBUtil.cs
+++ b/Yabber/YBUtil.cs
@@ -14,6 +14,25 @@ namespace Yabber
         private static readonly Regex TraversalRx = new Regex(@"^([(..)\\\/]+)(.+)?$");
         private static readonly Regex SlashRx = new Regex(@"^(\\+)(.+)$");
 
+        public static string FindCommonRootPath(IEnumerable<string> paths)
+        {
+            string root = "";
+
+            var rootPath = new string(
+                paths.First().Substring(0, paths.Min(s => s.Length))
+                    .TakeWhile((c, i) => paths.All(s => s[i] == c)).ToArray());
+
+            var rootPathIndex = Math.Max(rootPath.LastIndexOf('\\'), rootPath.LastIndexOf('/'));
+
+            if (rootPath != "" && rootPathIndex != -1)
+            {
+                // A shared root path exists; write it into the XML and use it for paths.
+                root = rootPath.Substring(0, rootPathIndex);
+            }
+
+            return root;
+        }
+
         /// <summary>
         /// Removes common network path roots if present.
         /// </summary>


### PR DESCRIPTION
Apparently Yabber already had mechanisms in place for detecting the long-winded root paths of Binder archives so that the enduser doesn't have to deal with them.

For ELDEN RING, these were not present because the ER paths weren't entered in the according list. Also, the mechanism generally isn't super good because it could just read the common root path from the files rather than rely on some preset list.

This PR changes that, and reads the common root path from the file list inside the binder, depositing it inside the "root" XML node.

The result: Shaving off the entire structure of `GR\data\INTERROOT_win64\script\talk\m00_00_00_00` when extracting a talkesdbnd file.